### PR TITLE
fix setting registration

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -106,7 +106,7 @@ function render_settings_field() {
 	$repo = get_option( 'dc-repo' );
 
 	?>
-	<input type="text" id="dc-repo" class="regular-text" name="dashboard_changelog[repository]" value="<?php echo esc_attr( $repo ); ?>" />
+	<input type="text" id="dc-repo" class="regular-text" name="dc-repo" value="<?php echo esc_attr( $repo ); ?>" />
 
 	<p class="description">
 		<?php esc_html_e( 'Add the repository user and name, e.g. jazzsequence/dashboard-changelog.', 'js-dashboard-changelog' ); ?>


### PR DESCRIPTION
This fixes the WordPress setting registration functions.

The custom function `get_repository_option` is removed entirely in favor of just `get_option`. Options are stored directly into and fetched from the `dc-repo` option and inputs are updated accordingly.

Fixes #7

### To test

The build tools _should_ be building the composer dependencies, however pulling down the repository or composer-require-ing it may not load parsedown -- which has been merged since the last release. So a `composer install` may be required to prevent errors in the widget.

1. Install this branch of Dashboard Changelog, either by git `clone`ing it or by using `composer require jazzsequence/dashboard-changelog@dev-7-fix-setting-registration`
2. Run `composer install` to ensure that you get the required libraries added in #6 
2. Navigate to the General Settings page in your WordPress adming
3. Add a repository to the GitHub Repo field and save
4. The setting should be saved after the page reloads & the changelog should appear in the dashboard.