### PR TITLE
Feat: local autoload

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -31,6 +31,13 @@
 
 namespace jazzsequence\DashboardChangelog;
 
+define( 'DC_PLUGIN_ROOT', plugin_dir_path( __FILE__ ) );
+
+$autoload_path = DC_PLUGIN_ROOT . 'vendor/autoload.php';
+
+if ( file_exists( $autoload_path ) ) {
+	require_once $autoload_path;
+}
 require_once __DIR__ . '/inc/api.php';
 require_once __DIR__ . '/inc/namespace.php';
 require_once __DIR__ . '/inc/widget.php';


### PR DESCRIPTION
Require local composer autoload only if it exists, opening the possibility of making this plugin a standalone one (the vendor folder would need to be included in the package).

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>