### PR TITLE
Feat: admin notice on new release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,24 @@
 # Dashboard Changelog
 
 **Contributors:** [Chris Reynolds](https://chrisreynolds.io)  
-**Donate link:** https://paypal.me/jazzsequence  
+**Donate link:** <https://paypal.me/jazzsequence>  
 **License:** GPLv3  
-**License URI:** https://www.gnu.org/licenses/gpl-3.0.html  
+**License URI:** <https://www.gnu.org/licenses/gpl-3.0.html>
 
 Adds a GitHub release widget to your WordPress dashboard for a public GitHub repository.
 
-## Installation ##
+## Installation
 
 1. Download the zip file, unzip, and upload to your `/wp-content/plugins/` directory.
 2. Activate Dashboard Changelog through the 'Plugins' menu in WordPress.
 3. Go to your General Settings page, and add the repository you'd like to display updates from in <owner>/<repository-name> format (e.g. `jazzsequence/dashboard-changelog`).
 4. For private repositories, add a GitHub Personal Access Token (PAT) to allow the plugin to fetch data on your behalf. You can get a PAT in your [GitHub settings](https://github.com/settings/tokens), or by following this [official guide](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token).
 
-## How to use ##
+## How to use
+
 By default, Dashboard Changelog will pull updates from GitHub _releases_, with the body content of each release acting as content for each update. In order to use, your repository will need to use releases. (The GitHub API endpoint can be modified to use any endpoint that is available, however additional customization would likely need to be done to format the data that gets pulled into the update.) The plugin will pull the 3 most recent releases and cache the API data for 24 hours.
 
-## Screenshots ##
+## Screenshots
 
 ![Dashboard changelog appearance](https://i.imgur.com/HxQ52rS.png)
 [Dashboard Changelog appearance.]
@@ -25,11 +26,12 @@ By default, Dashboard Changelog will pull updates from GitHub _releases_, with t
 ![Dashboard changelog setting](https://i.imgur.com/8jWxntT.png)
 [Dashboard Changelog setting in General Settings.]
 
-## Developer Reference ##
+## Developer Reference
 
 There are a number of filter hooks that can be used to modify the plugin to suit your needs. By default, this plugin was built to pull GitHub releases, specifically. but this can be changed to any API endpoint the GitHub API provides, or, potentially, pull updates from any public API.
 
 ### `dc.api_expiration`
+
 Filters the cache expiration time.
 
 API requests are filtered using `wp_cache_set` and `wp_cache_get` so we are making as few hits to the API as possible. By default, cached data from the API is stored for 1 day. You can filter this to whatever length you would prefer.
@@ -39,25 +41,37 @@ API requests are filtered using `wp_cache_set` and `wp_cache_get` so we are maki
 **`$expire`** _(int)_ The length to retain cached response codes.
 
 ### `dc.api.url`
+
 The API URL
 
 By default, this is `https://api.github.com/repos`, the GitHub API endpoint for repositories, specifically. If you want to use a completely different API, you can filter this variable.
 
 #### Parameters
+
 **`$base_url`** _(string)_ The API URL to filter.
 
 ### `dc.widget.max_display`
+
 The number of updates to display.
 
 By default, we display 3 updates (releases) from the API, but this can be updates here.
 
 #### Parameters
+
 **`$max_display`** _(int)_ The number of release updates to display.
 
 ## `JSDC_REPOSITORY`
+
 Global constant that can be used to hard-code the repository. If defined, the setting does not display in general settings. This constant can be defined in the `wp-config.php` file or elsewhere.
 
 ## `JSDC_PAT`
+
 Global constant that can be used to hard-code the Personal Access Token. If defined, the setting does not display in general settings. This constant can be defined in the `wp-config.php` file or elsewhere.
+
+**Note:** There is no validation done on these strings, so make sure they're saved in the proper format.
+
+## `JSDC_ADMIN_NOTICE`
+
+Global constant to force showing admin notices on each new release. If set, the setting does not display in general settings. Set it to 1 (enable) or 0 (disable).This constant can be defined in the `wp-config.php` file or elsewhere.
 
 **Note:** There is no validation done on these strings, so make sure they're saved in the proper format.

--- a/inc/api.php
+++ b/inc/api.php
@@ -77,9 +77,9 @@ function get_code( array $response = [] ) : int {
  * @return object The body of the API response, or an object containing an error message and information about what went wrong.
  */
 function get_body() : array {
-	$body = wp_cache_get( 'dc.api.cached_body' );
+	$json_body = wp_cache_get( 'dc.api.cached_body' );
 
-	if ( ! $body ) {
+	if ( ! $json_body ) {
 		$response = get_data();
 		$code = get_code();
 		$expire = DashboardChangelog\get_cache_expiration();
@@ -92,11 +92,14 @@ function get_body() : array {
 			return $body;
 		}
 
-		$body = wp_remote_retrieve_body( $response );
-		wp_cache_set( 'dc.api.cached_body', $body, null, $expire );
+		$json_body = wp_remote_retrieve_body( $response );
+		wp_cache_set( 'dc.api.cached_body', $json_body, null, $expire );
 	}
 
-	return json_decode( $body );
+	$body = json_decode( $json_body );
+	do_action( 'jsdc_body_retrieved', $body );
+
+	return $body;
 }
 
 /**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -22,6 +22,10 @@ function bootstrap() {
 	if ( ! defined( 'JSDC_PAT' ) ) {
 		add_action( 'admin_init', __NAMESPACE__ . '\\add_pat_setting' );
 	}
+
+	if ( ! defined( 'JSDC_ADMIN_NOTICE' ) ) {
+		add_action( 'admin_init', __NAMESPACE__ . '\\add_admin_notice_setting' );
+	}
 }
 
 /**
@@ -96,6 +100,31 @@ function add_pat_setting() {
 }
 
 /**
+ * Register the admin notice setting and add the field.
+ */
+function add_admin_notice_setting() {
+	add_settings_field(
+		'dc-admin-notice',
+		__( 'Admin notice', 'js-dashboard-changelog' ),
+		__NAMESPACE__ . '\\render_admin_notice_settings_field',
+		'general',
+		'default',
+		[
+			'label_for' => 'dc-admin-notice',
+		]
+	);
+
+	register_setting(
+		'general',
+		'dc-admin-notice',
+		[
+			'sanitize_callback' => __NAMESPACE__ . '\\sanitize_checkbox',
+			'default'           => '',
+		]
+	);
+}
+
+/**
  * Display the input field for the GitHub repository.
  */
 function render_repo_settings_field() {
@@ -125,6 +154,23 @@ function render_pat_settings_field() {
 	<?php
 }
 
+
+/**
+ * Display the checkbox field for the admin notices.
+ */
+function render_admin_notice_settings_field() {
+	$admin_notice = get_option( 'dc-admin-notice' );
+
+	?>
+	<fieldset>
+		<legend class="screen-reader-text"><span>Changelog translation</span></legend>
+		<label for="dc-admin-notice">
+			<input type="checkbox" id="dc-admin-notice" name="dc-admin-notice" value="1" <?php checked( 1, $admin_notice, true ); ?> />
+			<?php esc_html_e( 'Show a dismissable notice on new releases.', 'js-dashboard-changelog' ); ?>
+		</label>
+	</fieldset>
+	<?php
+}
 
 /**
  * Get the repository to fetch updates from.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -30,7 +30,9 @@ require dirname( __DIR__ ) . '/plugin.php';
 $options = [
 	'repo' => 'jazzsequence/dashboard-changelog',
 	'pat' => '1234567890',
+	'admin-notice' => "1",
 ];
 
 defined( 'JSDC_REPOSITORY' ) or define( 'JSDC_REPOSITORY', $options['repo'] );
 defined( 'JSDC_PAT' ) or define( 'JSDC_PAT', $options['pat'] );
+defined( 'JSDC_ADMIN_NOTICE' ) or define( 'JSDC_ADMIN_NOTICE', $options['admin-notice'] );


### PR DESCRIPTION
Closes jazzsequence/dashboard-changelog#21
- [x] add a setting to enable notices
- [x] add an action hook after GH API response body gets retrieved
- [ ] set a user meta to the last viewed release
- [ ] add an action to display notice 
